### PR TITLE
v0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-slackbot"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Steven Pequeno <steven@pequeno.in>"]
 description = "a slack bot for sanantoniodevs.slack.com"
 license = "GPL-3.0-or-later"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use slack::{Event, EventHandler, Message, RtmClient};
 mod reader;
 use env_logger;
 use log::info;
-use reader::*;
+use reader::read_feeds;
 
 struct Handler;
 
@@ -16,7 +16,7 @@ pub enum SlackChannel {
 }
 
 impl SlackChannel {
-    pub fn channel_id(&self) -> &'static str {
+    pub fn id(&self) -> &'static str {
         match self {
             SlackChannel::Aws => "CA6MUA4LU",
             SlackChannel::Rust => "C8EHWNKHV",


### PR DESCRIPTION
- change `SlackChannel::channel_id()` to `SlackChannel::id()`
- remove extra `Debug`
- clean up some functions
- change most feeds to "live"